### PR TITLE
Add initializer method on the L2BeaconRoots contract

### DIFF
--- a/contracts/src/L1BeaconRootsSender.sol
+++ b/contracts/src/L1BeaconRootsSender.sol
@@ -19,7 +19,7 @@ contract L1BeaconRootsSender {
     L2BeaconRoots public immutable L2_BEACON_ROOTS;
 
     /// @notice The required gas limit for executing the set function on the L2BeaconRoots contract
-    uint32 public constant L2_BEACON_ROOTS_SET_GAS_LIMIT = 25_000;
+    uint32 public constant L2_BEACON_ROOTS_SET_GAS_LIMIT = 27_000;
 
     /// @notice Event emitted when a block root is sent to the L2
     /// @notice The event can be emitted multiple times for the same block root

--- a/contracts/src/L2BeaconRoots.sol
+++ b/contracts/src/L2BeaconRoots.sol
@@ -16,10 +16,14 @@ contract L2BeaconRoots {
     IL2CrossDomainMessenger public immutable MESSENGER;
 
     /// @notice The L1BeaconRootsSender contract on the L1
-    address public immutable L1_BEACON_ROOTS_SENDER;
+    address public L1_BEACON_ROOTS_SENDER;
 
     /// @notice The beacon chain block roots stored by timestamps
     mapping(uint256 => bytes32) public beaconRoots;
+
+    /// @notice Event emitted when the smart contract is initialized
+    /// @param _l1BeaconRootsSender: The address of the L1BeaconRootsSender contract on L1
+    event Initialized(address _l1BeaconRootsSender);
 
     /// @notice Event emitted when a beacon block root is set
     /// @notice The event can be emitted multiple times for the same block root
@@ -30,10 +34,20 @@ contract L2BeaconRoots {
     event BeaconRootSet(uint256 timestamp, bytes32 blockRoot);
 
     /// @param _messenger: The address of the L2 CrossDomainMessenger contract
-    /// @param _l1BeaconRootsSender: The address of the L1 BeaconRootsSender contract
-    constructor(address _messenger, address _l1BeaconRootsSender) {
+    constructor(address _messenger) {
         MESSENGER = IL2CrossDomainMessenger(_messenger);
+    }
+
+    /// @notice Initialize the contract with the L1BeaconRootsSender address.
+    /// @param _l1BeaconRootsSender: The address of the L1BeaconRootsSender contract
+    /// @dev The flow is:
+    ///       1) Deploy L2BeaconRoots on L2
+    ///       2) Deploy L1BeaconRootsSender on L1 (passing the address of the deployed L2BeaconRoots to the constructor)
+    ///       3) Initialize L2BeaconRoots with the L1BeaconRootsSender address
+    function init(address _l1BeaconRootsSender) public {
+        require(address(L1_BEACON_ROOTS_SENDER) == address(0), "BeaconRoots: Contract has already been initialized");
         L1_BEACON_ROOTS_SENDER = _l1BeaconRootsSender;
+        emit Initialized(_l1BeaconRootsSender);
     }
 
     /// @notice Sets the beacon root for a given beacon chain timestamp

--- a/contracts/test/L1BeaconRootsSender.test.sol
+++ b/contracts/test/L1BeaconRootsSender.test.sol
@@ -23,7 +23,7 @@ contract L1BeaconRootsSenderTest is Test {
     address internal constant BEACON_ROOTS_ADDRESS = 0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02;
     uint256 internal constant BEACON_ROOTS_HISTORY_BUFFER_LENGTH = 8191;
     uint256 internal constant BEACON_SECONDS_PER_SLOT = 12;
-    uint32 internal constant L2_BEACON_ROOTS_SET_GAS_LIMIT = 25_000;
+    uint32 internal constant L2_BEACON_ROOTS_SET_GAS_LIMIT = 27_000;
 
     function setUp() public {
         l1CrossDomainMessengerMock = new L1CrossDomainMessengerMock();

--- a/contracts/test/L2BeaconRoots.test.sol
+++ b/contracts/test/L2BeaconRoots.test.sol
@@ -18,12 +18,13 @@ contract L1BeaconRootsSenderTest is Test {
     address internal l1BeaconRootsSender;
 
     // Constants
-    uint32 internal constant L2_BEACON_ROOTS_SET_GAS_LIMIT = 25_000;
+    uint32 internal constant L2_BEACON_ROOTS_SET_GAS_LIMIT = 27_000;
 
     function setUp() public {
         l2CrossDomainMessengerMock = new L2CrossDomainMessengerMock();
         l1BeaconRootsSender = makeAddr("l1BeaconRootsSender");
-        l2BeaconRoots = new L2BeaconRoots(address(l2CrossDomainMessengerMock), address(l1BeaconRootsSender));
+        l2BeaconRoots = new L2BeaconRoots(address(l2CrossDomainMessengerMock));
+        l2BeaconRoots.init(address(l1BeaconRootsSender));
     }
 
     function test_set() public {


### PR DESCRIPTION
# Description

Add an initializer method on the L2BeaconRoots contract. The initializer enables to pass the L1BeaconRootsSender address after deployment.

It enables to simplify the deployment of the protocol, so it does not require to predict the future deployment addresses of the smart contracts on L1 and L2.

## Deployment flow

1. Deploy L2BeaconRoots on L2
2. Deploy L1BeaconRootsSender on L1 passing the address of the deployed L2BeaconRoots to the constructor
3. Initialize L2BeaconRoots with the L1BeaconRootsSender address

# Notice

- [x]  Have you added relevant documentation?
- [x]  Have you added sufficient documentation in your code?
- [x]  Have you added relevant tests?

# Pull Request Type

- [x] 💫 New Feature (Breaking Change)
- [ ]  💫 New Feature (Non-breaking Change)
- [ ]  🛠️ Bug fix (Non-breaking Change: Fixes an issue)
- [ ]  🕹️ Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)